### PR TITLE
Fix Javadoc class reference

### DIFF
--- a/java-core/jc03_tipos_de_datos/src/main/java/com/pe/sectorcode/ejercicio3/ComparaNumeroRepe1.java
+++ b/java-core/jc03_tipos_de_datos/src/main/java/com/pe/sectorcode/ejercicio3/ComparaNumeroRepe1.java
@@ -3,7 +3,7 @@ package com.pe.sectorcode.ejercicio3;
 import java.util.Scanner;
 
 /***
- * Crea en una nueva clase llamada �ComparaNumerosRepe� la misma l�gica del
+ * Crea en una nueva clase llamada �ComparaNumeroRepe1� la misma l�gica del
  * ejercicio anterior,pero ahora solicita repetidamente al usuario los n�meros
  * hasta que los ingrese menores a 10.
  * 


### PR DESCRIPTION
## Summary
- update introductory Javadoc in `ComparaNumeroRepe1` to mention the correct class name

## Testing
- `mvn -q -pl java-core/jc03_tipos_de_datos test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c0078df883218e3894fd378b0f8b